### PR TITLE
Snowflake might create SqlAlchemy database name like <DATABASE_NAME>/<SCHEMA_NAME>

### DIFF
--- a/odd_great_expectations/dataset/sql_table.py
+++ b/odd_great_expectations/dataset/sql_table.py
@@ -20,9 +20,10 @@ def postgres_dataset(engine: Engine, batch_data: SqlAlchemyBatchData) -> str:
 
 
 def snowflake_dataset(engine: Engine, batch_data: SqlAlchemyBatchData) -> str:
+    # Snowflake might create SqlAlchemy database name like <DATABASE_NAME>/<SCHEMA_NAME>
     generator_params = {
         "host_settings": engine.engine.url.host,
-        "databases": engine.engine.url.database,
+        "databases": engine.engine.url.database.split('/')[0],
         "schemas": batch_data.source_schema_name or "public",
         "tables": batch_data.source_table_name,
     }


### PR DESCRIPTION
We are forced to handle the case when the connection string assembled according to the scheme `"connection_string": "snowflake://<USER_NAME>:<PASSWORD>@<ACCOUNT_NAME>/<DATABASE_NAME>/<SCHEMA_NAME>?warehouse=<WAREHOUSE_NAME>&role=<ROLE_NAME>&application=great_expectations_oss" ` can have a compound database name `<DATABASE_NAME>/<SCHEMA_NAME>`